### PR TITLE
TRIVIAL: use ESLint instead of TSLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "mrmlnc"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ npm-debug.log*
 node_modules/
 
 # Compiled and temporary files
+.eslintcache
 .tmp/
 out/
 build/

--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,10 @@
 .gitignore
 .vsts
 tsconfig.json
-tslint.json
+.eslintrc.json
+
+# Log & Cache files
+.eslintcache
 
 # Output files
 out/tests

--- a/.vsts/build.yml
+++ b/.vsts/build.yml
@@ -19,13 +19,13 @@ jobs:
           NODE_VERSION: 12.x
 
         WINDOWS_NODE_8:
-          IMAGE_TYPE: 'windows-latest'
+          IMAGE_TYPE: 'vs2017-win2016'
           NODE_VERSION: 8.x
         WINDOWS_NODE_10:
-          IMAGE_TYPE: 'windows-latest'
+          IMAGE_TYPE: 'vs2017-win2016'
           NODE_VERSION: 10.x
         WINDOWS_NODE_12:
-          IMAGE_TYPE: 'windows-latest'
+          IMAGE_TYPE: 'vs2017-win2016'
           NODE_VERSION: 12.x
 
         MACOS_NODE_8:

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "@types/bindings": "^1.3.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.10.53",
+    "eslint": "^6.5.1",
+    "eslint-config-mrmlnc": "^1.0.1",
     "mocha": "^6.2.0",
     "rimraf": "^3.0.0",
-    "tslint": "^5.19.0",
-    "tslint-config-mrmlnc": "^2.1.0",
     "typescript": "^3.6.2"
   },
   "dependencies": {
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "clean": "rimraf out",
-    "lint": "tslint \"src/typescript/**/*.ts\" -p . -t stylish",
+    "lint": "eslint \"src/typescript/**/*.ts\" --cache",
     "compile:cpp": "node-gyp configure build",
     "compile:ts": "tsc",
     "compile": "npm run compile:cpp && npm run compile:ts",

--- a/src/typescript/index.spec.ts
+++ b/src/typescript/index.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import * as pkg from './index';
+import * as pkg from '.';
 
 describe('Addon', () => {
 	describe('.sum', () => {
@@ -8,10 +8,10 @@ describe('Addon', () => {
 
 		it('should return the sum of two integer numbers', (done) => {
 			pkg.sum(1, 1, (error, result) => {
-				if (error) {
-					assert.fail(error.message);
-				} else {
+				if (error === null) {
 					assert.strictEqual(result, 2);
+				} else {
+					assert.fail(error.message);
 				}
 
 				done();
@@ -20,10 +20,10 @@ describe('Addon', () => {
 
 		it('should return the sum of two float numbers', (done) => {
 			pkg.sum(1.3, 1.5, (error, result) => {
-				if (error) {
-					assert.fail(error.message);
-				} else {
+				if (error === null) {
 					assert.strictEqual(result, 2.8);
+				} else {
+					assert.fail(error.message);
 				}
 
 				done();

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -1,11 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 import bindings = require('bindings');
 
-type Callback = (error: NodeJS.ErrnoException, result: number) => void;
+type Callback = (error: NodeJS.ErrnoException | null, result: number) => void;
 
-export interface AddonApi {
+export type AddonApi = {
 	sum(a: number, b: number, callback: Callback): void;
 	sumSync(a: number, b: number): number;
-}
+};
 
 const { sum, sumSync } = bindings('addon.node') as AddonApi;
 

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,0 @@
-{
-	"extends": [
-		"tslint-config-mrmlnc"
-	]
-}


### PR DESCRIPTION
### What is the purpose of this pull request?

Upgrading the infrastructure of the repository. TSLint will be deprecated some time in 2019.

https://github.com/palantir/tslint/issues/4534